### PR TITLE
Use base Response class

### DIFF
--- a/src/Middleware/LastModifiedHandling.php
+++ b/src/Middleware/LastModifiedHandling.php
@@ -7,8 +7,8 @@ namespace Abordage\LastModified\Middleware;
 use Abordage\LastModified\Facades\LastModified;
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
+use Symfony\Component\HttpFoundation\Response;
 
 class LastModifiedHandling
 {


### PR DESCRIPTION
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.


> 💡 Please take note of our [contributing guidelines](https://github.com/abordage/.github/blob/master/CONTRIBUTING.md)

1. Why should it be added? What are the benefits of this change?
Laravel's JsonResponse doesn't inherit from `Illuminate\Http\Response` but Symfony's JsonResponse class. This change allows all response types to be used.
2. Does it contain multiple, unrelated changes? Please separate the PRs out.
3. Does it include tests, if possible?
This is already covered by the existing tests.
4. Any drawbacks? Possible breaking changes?

**Mark the following tasks as done:**
- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [x] Added tests to ensure against regression.
- [ ] Updated the changelog

### Thanks for contributing!
